### PR TITLE
Fix installation procedure to work with Debian 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,32 @@
 
 Web app for the MBot Omni robot.
 
-## Dependencies
+## Installing from the Latest Release (Recommended)
+
+To install the MBot web app, get the latest release from the [releases page](https://github.com/mbot-project/mbot_web_app/releases). Then, on a terminal in your MBot, install as follows:
+```bash
+# Note: Replace $VERSION with your desired version
+# OR do "export VERSION=vX.Y.Z", substituting the latest version number.
+wget https://github.com/mbot-project/mbot_web_app/releases/download/$VERSION/mbot_web_app-$VERSION.tar.gz
+tar -xvzf mbot_web_app-$VERSION.tar.gz
+```
+Install the dependencies:
+```bash
+cd mbot_web_app-$VERSION/
+./install_nginx.sh
+./install_python_deps.sh
+```
+Then deploy the app:
+```bash
+./deploy_app.sh --no-rebuild
+```
+You can now safely delete the files you downloaded and extracted.
+
+## Installing from Source
+
+To build from source, or to develop locally, follow these steps.
+
+### Dependencies
 
 The front end relies on NodeJS (to compile and run the JavaScript files), NPM (a
 package manager for NodeJS applications) and React, as well as some other
@@ -16,9 +41,9 @@ nvm install 18
 ```
 Now you should have the `node` and `npm` command installed. You can check with `node --version` and `npm --version`.
 
-## Setup on a Robot
+### Installing from Source on a Robot
 
-To set up the webapp on a new robot, use the helper scripts. First, install nginx and the Python dependencies:
+To set up the webapp on a new robot from source, use the helper scripts. First, install nginx and the Python dependencies:
 ```bash
 ./scripts/install_nginx.sh
 ./scripts/install_python_deps.sh
@@ -31,9 +56,9 @@ The webapp is accessible by typing the robot's IP into the browser.
 
 Once you have done the setup once, you only need to rerun the `deploy_app.sh` script in order to update the webapp code with a new version.
 
-## Local Execution
+## Development Mode
 
-If you are developing this app and want to run it locally, follow these instructions.
+If you are developing this app and want to run it locally, follow these instructions. You will need to run both the front end and the back end.
 
 ### Front end
 
@@ -60,7 +85,7 @@ webapp.
 
 ### Back end
 
-The backend is build using Flask and Python 3. If
+The backend is built using Flask and Python 3. If
 working on a Linux computer, you probably want to run the code in a virtual
 environment (on the Raspberry Pi, you can install things directly if you want).
 To make a virtual environment and then activate it, do:
@@ -96,3 +121,8 @@ npm run start-api
 
 Traffic on `http://[SERVER_IP]:8000` will be forwarded to `http://[SERVER_IP]:5000`,
 where the Flask server is running.
+
+**Note:** If you have the webapp installed already, you will need to stop the backend service to run it locally so that the two don't conflict. To stop the installed server, do:
+```bash
+sudo systemctl stop mbot-web-server.service
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MBot Omni App
+# MBot Web App
 
-Web app for the MBot Omni robot.
+Web app for the MBot robot.
 
 ## Installing from the Latest Release (Recommended)
 

--- a/config/mbot-web-server.service
+++ b/config/mbot-web-server.service
@@ -7,7 +7,8 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=1
-ExecStart=python3 /data/www/mbot/api/mbot_omni_app.py
+Environment="PYTHONPATH=$PYTHONPATH:PY_LIB_PATH"
+ExecStart=WEBAPP_ENV_PATH/bin/python3 /data/www/mbot/api/mbot_omni_app.py
 User=root
 
 [Install]

--- a/config/mbot-web-server.service
+++ b/config/mbot-web-server.service
@@ -7,7 +7,7 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=1
-ExecStart=WEBAPP_ENV_PATH/bin/python3 /data/www/mbot/api/mbot_omni_app.py
+ExecStart=python3 /data/www/mbot/api/mbot_omni_app.py
 User=root
 
 [Install]

--- a/config/mbot-web-server.service
+++ b/config/mbot-web-server.service
@@ -7,7 +7,6 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=1
-Environment="PYTHONPATH=$PYTHONPATH:PY_LIB_PATH"
 ExecStart=WEBAPP_ENV_PATH/bin/python3 /data/www/mbot/api/mbot_omni_app.py
 User=root
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -44,8 +44,13 @@ http {
 	server {
 		listen 80 default_server;
 		listen [::]:80 default_server;
-                server_name localhost home.bot www.home.mbot;
-		root /data/www/mbot;
+		server_name localhost home.bot www.home.mbot;
+
+		location / {
+			root /data/www/mbot;
+			index index.html index.htm;
+			try_files $uri $uri/ =404;
+		}
 
 	}
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head lang="en">
     <meta charset="UTF-8">
-    <title>ROB 102 - MBot Omni GUI</title>
+    <title>MBot Web App</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- styles -->
     <link rel="shortcut icon" type="image/png" href="/images/icon.png"/>

--- a/scripts/deploy_app.sh
+++ b/scripts/deploy_app.sh
@@ -32,10 +32,6 @@ echo
 ENVS_ROOT="/home/$USER/.envs"
 MBOT_APP_ENV="$ENVS_ROOT/mbot-app-env/"  # Virtual env where app is run.
 
-# Get the global Python library install path and add it to the path.
-PY_LIB_PATH=$(python3 -c "import site; print(site.getsitepackages()[0])")
-PY_LIB_PATH=$PY_LIB_PATH:/usr/lib/python3/dist-packages/
-
 if [ ! -d "/data/www/mbot/api" ]; then
     sudo mkdir /data/www/mbot/api
 fi
@@ -49,7 +45,6 @@ if [ ! -f "/etc/systemd/system/mbot-web-server.service" ]; then
   sudo cp config/mbot-web-server.service /etc/systemd/system/
   # Fill in the path to this env and the correct Python path.
   sudo sed -i "s#WEBAPP_ENV_PATH#$MBOT_APP_ENV#" /etc/systemd/system/mbot-web-server.service
-  sudo sed -i "s#PY_LIB_PATH#$PY_LIB_PATH#" /etc/systemd/system/mbot-web-server.service
 
   echo "Enabling MBot Web App service."
   # Reload the service.
@@ -61,7 +56,6 @@ else
   sudo cp config/mbot-web-server.service /etc/systemd/system/
   # Fill in the path to this env.
   sudo sed -i "s#WEBAPP_ENV_PATH#$MBOT_APP_ENV#" /etc/systemd/system/mbot-web-server.service
-  sudo sed -i "s#PY_LIB_PATH#$PY_LIB_PATH#" /etc/systemd/system/mbot-web-server.service
 
   echo "MBot Web App service is already enabled. Restarting it."
   sudo systemctl daemon-reload

--- a/scripts/deploy_app.sh
+++ b/scripts/deploy_app.sh
@@ -29,6 +29,13 @@ echo "Setting up Python server..."
 echo "#############################"
 echo
 
+ENVS_ROOT="/home/$USER/.envs"
+MBOT_APP_ENV="$ENVS_ROOT/mbot-app-env/"  # Virtual env where app is run.
+
+# Get the global Python library install path and add it to the path.
+PY_LIB_PATH=$(python3 -c "import site; print(site.getsitepackages()[0])")
+PY_LIB_PATH=$PY_LIB_PATH:/usr/lib/python3/dist-packages/
+
 if [ ! -d "/data/www/mbot/api" ]; then
     sudo mkdir /data/www/mbot/api
 fi
@@ -40,6 +47,9 @@ sudo cp -r app/ /data/www/mbot/api
 if [ ! -f "/etc/systemd/system/mbot-web-server.service" ]; then
   # This is the first time installing.
   sudo cp config/mbot-web-server.service /etc/systemd/system/
+  # Fill in the path to this env and the correct Python path.
+  sudo sed -i "s#WEBAPP_ENV_PATH#$MBOT_APP_ENV#" /etc/systemd/system/mbot-web-server.service
+  sudo sed -i "s#PY_LIB_PATH#$PY_LIB_PATH#" /etc/systemd/system/mbot-web-server.service
 
   echo "Enabling MBot Web App service."
   # Reload the service.
@@ -49,6 +59,9 @@ if [ ! -f "/etc/systemd/system/mbot-web-server.service" ]; then
 else
   # This service has already been installed. Pull new changes then restart it.
   sudo cp config/mbot-web-server.service /etc/systemd/system/
+  # Fill in the path to this env.
+  sudo sed -i "s#WEBAPP_ENV_PATH#$MBOT_APP_ENV#" /etc/systemd/system/mbot-web-server.service
+  sudo sed -i "s#PY_LIB_PATH#$PY_LIB_PATH#" /etc/systemd/system/mbot-web-server.service
 
   echo "MBot Web App service is already enabled. Restarting it."
   sudo systemctl daemon-reload

--- a/scripts/deploy_app.sh
+++ b/scripts/deploy_app.sh
@@ -29,8 +29,6 @@ echo "Setting up Python server..."
 echo "#############################"
 echo
 
-MBOT_APP_ENV="/home/$USER/envs/mbot-app-env/"  # Virtual env where app is run.
-
 if [ ! -d "/data/www/mbot/api" ]; then
     sudo mkdir /data/www/mbot/api
 fi
@@ -42,8 +40,6 @@ sudo cp -r app/ /data/www/mbot/api
 if [ ! -f "/etc/systemd/system/mbot-web-server.service" ]; then
   # This is the first time installing.
   sudo cp config/mbot-web-server.service /etc/systemd/system/
-  # Fill in the path to this env.
-  sudo sed -i "s#WEBAPP_ENV_PATH#$MBOT_APP_ENV#" /etc/systemd/system/mbot-web-server.service
 
   echo "Enabling MBot Web App service."
   # Reload the service.
@@ -53,8 +49,6 @@ if [ ! -f "/etc/systemd/system/mbot-web-server.service" ]; then
 else
   # This service has already been installed. Pull new changes then restart it.
   sudo cp config/mbot-web-server.service /etc/systemd/system/
-  # Fill in the path to this env.
-  sudo sed -i "s#WEBAPP_ENV_PATH#$MBOT_APP_ENV#" /etc/systemd/system/mbot-web-server.service
 
   echo "MBot Web App service is already enabled. Restarting it."
   sudo systemctl daemon-reload

--- a/scripts/install_python_deps.sh
+++ b/scripts/install_python_deps.sh
@@ -5,11 +5,34 @@ echo "###################################"
 echo " Installing Python Dependencies..."
 echo "###################################"
 
-sudo apt install -y python3-flask \
-                    python3-flask-socketio \
-                    python3-flask-cors \
-                    python3-dotenv \
-                    python3-eventlet
+ENVS_ROOT="/home/$USER/.envs"
+MBOT_APP_ENV="$ENVS_ROOT/mbot-app-env/"
+
+# Get the global Python library install path and add it to the path.
+PY_LIB_PATH=$(python3 -c "import site; print(site.getsitepackages()[0])")
+PYTHONPATH=$PYTHONPATH:/usr/lib/python3/dist-packages/:$PY_LIB_PATH
+
+# Create a new env if applicable
+if [ ! -d $ENVS_ROOT ]; then
+    mkdir $ENVS_ROOT
+fi
+
+# Create a new env if applicable
+if [ ! -d $MBOT_APP_ENV ]; then
+    python3 -m venv $MBOT_APP_ENV
+fi
+
+# Ensure numpy is globally installed, since on the Raspberry Pi the pip wheel doesn't work.
+sudo apt install -y python3-numpy
+
+source $MBOT_APP_ENV/bin/activate
+
+# Install the Python requirements into the env.
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+
+# Deactivate becayse we're done with the env now.
+deactivate
 
 echo
 echo "Done!"

--- a/scripts/install_python_deps.sh
+++ b/scripts/install_python_deps.sh
@@ -8,18 +8,14 @@ echo "###################################"
 ENVS_ROOT="/home/$USER/.envs"
 MBOT_APP_ENV="$ENVS_ROOT/mbot-app-env/"
 
-# Get the global Python library install path and add it to the path.
-PY_LIB_PATH=$(python3 -c "import site; print(site.getsitepackages()[0])")
-PYTHONPATH=$PYTHONPATH:/usr/lib/python3/dist-packages/:$PY_LIB_PATH
-
-# Create a new env if applicable
+# Create env environment if applicable
 if [ ! -d $ENVS_ROOT ]; then
     mkdir $ENVS_ROOT
 fi
 
-# Create a new env if applicable
+# Create a new env if applicable, and share the site packages.
 if [ ! -d $MBOT_APP_ENV ]; then
-    python3 -m venv $MBOT_APP_ENV
+    python3 -m venv --system-site-packages $MBOT_APP_ENV
 fi
 
 # Ensure numpy is globally installed, since on the Raspberry Pi the pip wheel doesn't work.

--- a/scripts/install_python_deps.sh
+++ b/scripts/install_python_deps.sh
@@ -1,42 +1,16 @@
 #!/bin/bash
 set -e  # Quit on error.
 
-echo "#############################"
-echo "Setting up Python server..."
-echo "#############################"
+echo "###################################"
+echo " Installing Python Dependencies..."
+echo "###################################"
 
-MBOT_APP_ENV="/home/$USER/envs/mbot-app-env/"
-
-# Create a new env if applicable
-if [ ! -d $MBOT_APP_ENV ]; then
-    python3 -m venv $MBOT_APP_ENV
-fi
-
-# Before activating, get the Python path where the LCM packages are installed.
-MSGS_PATH=$(python3 -c "if True:
-  import mbot_lcm_msgs
-  print(mbot_lcm_msgs.__path__[0])")
-LCM_PATH=$(python3 -c "if True:
-  import lcm
-  print(lcm.__path__[0])")
-
-# Activate the environment.
-source $MBOT_APP_ENV/bin/activate
-
-# After activating, get the Python path where packages are installed in the env.
-ENV_PYTHON_PKG_PATH=$(python3 -c "if True:
-  import sysconfig as sc
-  print(sc.get_path('platlib'))")
+sudo apt install -y python3-flask \
+                    python3-flask-socketio \
+                    python3-flask-cors \
+                    python3-dotenv \
+                    python3-eventlet
 
 echo
-echo "Installing Python dependencies..."
+echo "Done!"
 echo
-
-pip install --upgrade pip
-pip install -r requirements.txt
-# Copy messages and LCM into this environment. TODO: Fix this.
-rsync -av --exclude='*.pyc' --exclude='*/__pycache__/' $MSGS_PATH $ENV_PYTHON_PKG_PATH
-rsync -av --exclude='*.pyc' --exclude='*/__pycache__/' $LCM_PATH $ENV_PYTHON_PKG_PATH
-
-# Deactivate becayse we're done with the env now.
-deactivate


### PR DESCRIPTION
Updates to support Debian 12. This has been tested on Debian 11 and Rasbian 12.
* Updates the `pip` commands to `python -m pip` as currently recommended. 
* Fixes an issue with installing NumPy via pip which is broken on Debian 12 by just installing from apt first
* Adds site installs to the environment rather than manually copying the needed libraries
* Updates the documentation

Fixes #18 
