### PR TITLE
Bump Bridge version to latest compatible one

### DIFF
--- a/scripts/deploy_app.sh
+++ b/scripts/deploy_app.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e  # Quit on error.
 
-BRIDGE_VERSION="v1.0.0"  # The MBot Bridge version to download if no path is passed.
+BRIDGE_VERSION="v1.1.0"  # The MBot Bridge version to download if no path is passed.
 BRIDGE_PATH=""           # The path to a local version of MBot Bridge. Overrides downloading a release.
 REBUILD_APP=true         # Whether to rebuild the app.
 


### PR DESCRIPTION
This script was missing an updated version to use the latest compatible release of MBot Bridge.